### PR TITLE
[core] convert the printing system to a generic BaseAdapter

### DIFF
--- a/django-manager/manager/settings/base.py
+++ b/django-manager/manager/settings/base.py
@@ -107,6 +107,11 @@ USE_TZ = True
 # application design must be updated
 CURRENCIES = ('EUR',)
 
+# list of Adapters that are used to push data to third party services
+PUSH_ADAPTERS = [
+    'registers.adapters.printers.CashRegisterAdapter',
+]
+
 # cash register settings
 REGISTER_PRINT = env('DJANGO_REGISTER_PRINT', False)
 REGISTER_NAME = env('DJANGO_REGISTER_NAME', 'Shop')

--- a/django-manager/manager/settings/base.py
+++ b/django-manager/manager/settings/base.py
@@ -109,11 +109,11 @@ CURRENCIES = ('EUR',)
 
 # list of Adapters that are used to push data to third party services
 PUSH_ADAPTERS = [
-    'registers.adapters.printers.CashRegisterAdapter',
+    # Available adapters are:
+    # 'registers.adapters.printers.CashRegisterAdapter',
 ]
 
 # cash register settings
-REGISTER_PRINT = env('DJANGO_REGISTER_PRINT', False)
 REGISTER_NAME = env('DJANGO_REGISTER_NAME', 'Shop')
 SERIAL_PORT = env('DJANGO_SERIAL_PORT', '/dev/ttyUSB0')
 SERIAL_BAUDRATE = env('DJANGO_SERIAL_BAUDRATE', 9600)

--- a/django-manager/manager/settings/production.py
+++ b/django-manager/manager/settings/production.py
@@ -6,9 +6,6 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 SECURE_SSL_REDIRECT = env('DJANGO_SECURE_SSL_REDIRECT', True)
 SESSION_COOKIE_SECURE = env('DJANGO_SESSION_COOKIE_SECURE', True)
 
-# cash register settings
-REGISTER_PRINT = env('DJANGO_REGISTER_PRINT', True)
-
 # static files
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 

--- a/django-manager/registers/__init__.py
+++ b/django-manager/registers/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'registers.apps.RegistersConfig'

--- a/django-manager/registers/adapters/base.py
+++ b/django-manager/registers/adapters/base.py
@@ -1,0 +1,14 @@
+class BaseAdapter(object):
+    """
+    BaseAdapter provides the interface that must be honored when
+    creating a new Adapter. This is used to add external integrations
+    when a receipt model is saved, pushing data to a third-party
+    component like a printer or a web service.
+    """
+    def push(self, items):
+        """
+        Push method is called when the serializer or the Django admin
+        stores data in the selected database. This method MUST be
+        implemented for any used `Adapter`.
+        """
+        raise NotImplementedError

--- a/django-manager/registers/adapters/printers.py
+++ b/django-manager/registers/adapters/printers.py
@@ -1,0 +1,40 @@
+from django.conf import settings
+
+from serial import Serial, SerialException
+from cash_register.models.xditron import SaremaX1
+
+from .base import BaseAdapter
+from ..exceptions import CashRegisterNotReady
+
+
+class CashRegisterAdapter(BaseAdapter):
+    """
+    CashRegisterAdapter uses the `python-cash-register` module
+    to push data to a real cash register. This is useful if you want
+    to use a web UI (or the Django Admin) to create your receipt.
+
+    Data are still persisted in the database so that backfilling
+    can be done.
+    """
+    def push(self, items):
+        """
+        Function that prints the passed arguments using a connected
+        cash register. It handles the serial communication, raising
+        an exception if something goes wrong.
+        """
+        try:
+            # define the serial port
+            conn = Serial()
+            conn.port = settings.SERIAL_PORT
+            conn.baudrate = settings.SERIAL_BAUDRATE
+            conn.xonxoff = settings.SERIAL_XONXOFF
+            conn.timeout = settings.SERIAL_TIMEOUT
+
+            # create a cash register with a serial connection handler
+            register = SaremaX1(settings.REGISTER_NAME, connection=conn)
+
+            # prepare and send cash register commands
+            register.sell_products(items)
+            register.send()
+        except SerialException:
+            raise CashRegisterNotReady

--- a/django-manager/registers/adapters/printers.py
+++ b/django-manager/registers/adapters/printers.py
@@ -22,20 +22,19 @@ class CashRegisterAdapter(BaseAdapter):
         cash register. It handles the serial communication, raising
         an exception if something goes wrong.
         """
-        if settings.REGISTER_PRINT:
-            try:
-                # define the serial port
-                conn = Serial()
-                conn.port = settings.SERIAL_PORT
-                conn.baudrate = settings.SERIAL_BAUDRATE
-                conn.xonxoff = settings.SERIAL_XONXOFF
-                conn.timeout = settings.SERIAL_TIMEOUT
+        try:
+            # define the serial port
+            conn = Serial()
+            conn.port = settings.SERIAL_PORT
+            conn.baudrate = settings.SERIAL_BAUDRATE
+            conn.xonxoff = settings.SERIAL_XONXOFF
+            conn.timeout = settings.SERIAL_TIMEOUT
 
-                # create a cash register with a serial connection handler
-                register = SaremaX1(settings.REGISTER_NAME, connection=conn)
+            # create a cash register with a serial connection handler
+            register = SaremaX1(settings.REGISTER_NAME, connection=conn)
 
-                # prepare and send cash register commands
-                register.sell_products(items)
-                register.send()
-            except SerialException:
-                raise CashRegisterNotReady
+            # prepare and send cash register commands
+            register.sell_products(items)
+            register.send()
+        except SerialException:
+            raise CashRegisterNotReady

--- a/django-manager/registers/adapters/printers.py
+++ b/django-manager/registers/adapters/printers.py
@@ -22,19 +22,20 @@ class CashRegisterAdapter(BaseAdapter):
         cash register. It handles the serial communication, raising
         an exception if something goes wrong.
         """
-        try:
-            # define the serial port
-            conn = Serial()
-            conn.port = settings.SERIAL_PORT
-            conn.baudrate = settings.SERIAL_BAUDRATE
-            conn.xonxoff = settings.SERIAL_XONXOFF
-            conn.timeout = settings.SERIAL_TIMEOUT
+        if settings.REGISTER_PRINT:
+            try:
+                # define the serial port
+                conn = Serial()
+                conn.port = settings.SERIAL_PORT
+                conn.baudrate = settings.SERIAL_BAUDRATE
+                conn.xonxoff = settings.SERIAL_XONXOFF
+                conn.timeout = settings.SERIAL_TIMEOUT
 
-            # create a cash register with a serial connection handler
-            register = SaremaX1(settings.REGISTER_NAME, connection=conn)
+                # create a cash register with a serial connection handler
+                register = SaremaX1(settings.REGISTER_NAME, connection=conn)
 
-            # prepare and send cash register commands
-            register.sell_products(items)
-            register.send()
-        except SerialException:
-            raise CashRegisterNotReady
+                # prepare and send cash register commands
+                register.sell_products(items)
+                register.send()
+            except SerialException:
+                raise CashRegisterNotReady

--- a/django-manager/registers/apiviews.py
+++ b/django-manager/registers/apiviews.py
@@ -7,7 +7,6 @@ from rest_framework.permissions import IsAdminUser
 from .models import Product, Receipt
 from .receipts import convert_serializer
 from .serializers import ProductSerializer, ReceiptSerializer
-from .adapters.printers import CashRegisterAdapter
 
 
 class ProductViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
@@ -48,9 +47,7 @@ class ReceiptViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
             # create the ``Receipt`` model, honoring the ManyToMany
             serializer.save()
 
-            if settings.REGISTER_PRINT:
-                # convert serializer validated_data and send it
-                # to the cash register printer
-                data = convert_serializer(serializer)
-                adapter = CashRegisterAdapter()
-                adapter.push(data)
+            # push items list to external services
+            items = convert_serializer(serializer)
+            for adapter in settings.PUSH_ADAPTERS:
+                adapter.push(items)

--- a/django-manager/registers/apps.py
+++ b/django-manager/registers/apps.py
@@ -1,5 +1,14 @@
 from django.apps import AppConfig
+from django.conf import settings
+from django.utils.module_loading import import_string
 
 
 class RegistersConfig(AppConfig):
     name = 'registers'
+
+    def ready(self):
+        """
+        Initializes all `registers` adapters after the application is loaded.
+        """
+        adapters_classes = [import_string(adapter) for adapter in settings.PUSH_ADAPTERS]
+        settings.PUSH_ADAPTERS = [Adapter() for Adapter in adapters_classes]

--- a/django-manager/registers/exceptions.py
+++ b/django-manager/registers/exceptions.py
@@ -1,10 +1,19 @@
 from rest_framework.exceptions import APIException
 
 
-class CashRegisterNotReady(APIException):
+class AdapterPushFailed(APIException):
     """
-    Generic exception when the communication with the cash
-    register doesn't work properly
+    Generic exception that happens when the communication with
+    an external service failed. When using Adapters, you should
+    expect a failure with this parent exception.
     """
     status_code = 500
+    default_detail = 'Adapter was unable to push data to the service.'
+
+
+class CashRegisterNotReady(AdapterPushFailed):
+    """
+    Exception when the communication with the cash register
+    doesn't work properly.
+    """
     default_detail = 'The connected cash register is not ready. Please check the connection'

--- a/django-manager/registers/receipts.py
+++ b/django-manager/registers/receipts.py
@@ -1,11 +1,5 @@
 from decimal import Decimal as D
 
-from serial import Serial
-
-from django.conf import settings
-
-from cash_register.models.xditron import SaremaX1
-
 
 # same as Decimal('0.01')
 TWOPLACES = D(10) ** -2
@@ -31,31 +25,10 @@ def convert_serializer(serializer):
         # Note: the current implementation expects that the shop
         # sells items in unit price instead of other measurement
         # units. Because of that, selling 0.50 kg of stuff
-        # doesn't work
+        # is not possible.
         if product['quantity'] > 1:
             quantity = str(product['quantity'].quantize(TWOPLACES))
             row.update({'quantity': quantity})
 
         items.append(row)
     return items
-
-
-def print_receipt(data):
-    """
-    Function that prints the passed arguments using a connected
-    cash register. It handles the serial communication, raising
-    an exception if something goes wrong.
-    """
-    # define the serial port
-    conn = Serial()
-    conn.port = settings.SERIAL_PORT
-    conn.baudrate = settings.SERIAL_BAUDRATE
-    conn.xonxoff = settings.SERIAL_XONXOFF
-    conn.timeout = settings.SERIAL_TIMEOUT
-
-    # create a cash register with a serial connection handler
-    register = SaremaX1(settings.REGISTER_NAME, connection=conn)
-
-    # prepare and send cash register commands
-    register.sell_products(data)
-    register.send()

--- a/django-manager/tests/test_adapters.py
+++ b/django-manager/tests/test_adapters.py
@@ -1,0 +1,76 @@
+"""
+These tests don't check the validity of the ViewSet or of the
+Serializer but only assert that the ``python-cash-register``
+integration works properly.
+"""
+import pytest
+
+from serial import SerialException
+
+from registers import adapters
+from registers.exceptions import AdapterPushFailed
+from registers.adapters.printers import CashRegisterAdapter
+
+
+@pytest.mark.django_db
+def test_cash_register_adapter(mocker):
+    """
+    Ensure that a list of sold items is printed:
+        * prepare a payload with 2 sold items
+        * push the adapter
+        * expect that the receipt is printed
+    """
+    # initialize the adapter
+    adapter = CashRegisterAdapter()
+    # spy third party libraries and mock the serial port
+    mocker.patch('registers.adapters.printers.Serial')
+    sell_products = mocker.spy(adapters.printers.SaremaX1, 'sell_products')
+    send = mocker.spy(adapters.printers.SaremaX1, 'send')
+    # sold products
+    sold_items = [
+        {
+            'description': 'Croissant',
+            'price': '5.90',
+        },
+        {
+            'description': 'Begel',
+            'price': '2.00',
+            'quantity': '2.00',
+        },
+    ]
+    # push data
+    adapter.push(sold_items)
+    assert sell_products.call_count == 1
+    assert send.call_count == 1
+
+
+@pytest.mark.django_db
+def test_cash_register_adapter_failure(mocker):
+    """
+    Ensure that an AdapterPushFailed is raised when using this
+    adapter:
+        * prepare a payload with 2 sold items
+        * push the adapter
+        * expect that an exception is raised
+    """
+    # initialize the adapter
+    adapter = CashRegisterAdapter()
+    # mock the serial port so that it raises an Exception
+    serial_port = mocker.patch('registers.adapters.printers.Serial')
+    serial_port.side_effect = SerialException
+    # sold products
+    sold_items = [
+        {
+            'description': 'Croissant',
+            'price': '5.90',
+        },
+        {
+            'description': 'Begel',
+            'price': '2.00',
+            'quantity': '2.00',
+        },
+    ]
+    # push data and check the Exception
+    with pytest.raises(AdapterPushFailed) as excinfo:
+        adapter.push(sold_items)
+    assert excinfo.typename == 'CashRegisterNotReady'

--- a/django-manager/tests/test_integration.py
+++ b/django-manager/tests/test_integration.py
@@ -9,30 +9,26 @@ from model_mommy import mommy
 
 from django.core.urlresolvers import reverse
 
-from serial import SerialException
-
-from registers import adapters
 from registers.models import Product, Receipt
 from registers.receipts import convert_serializer
+from registers.exceptions import CashRegisterNotReady
 from registers.serializers import ReceiptSerializer
 
 
 @pytest.mark.django_db
-def test_receipt_post_print(alice_client, mocker, settings):
+def test_endpoint_calls_adapters(alice_client, mocker, settings):
     """
-    Ensure that a POST on the receipt endpoint prints a receipt
-    through the connected cash register.
+    Ensure that a POST on the receipt endpoint calls all registered
+    adapters:
         * create two products
         * prepare a payload with 2 sold items
         * POST the message
-        * expect that the receipt is printed
+        * expect that the Adapter.push() is executed
     """
-    # force the print
-    settings.REGISTER_PRINT = True
-    # spy third party libraries and mock the serial port
-    mocker.patch('registers.adapters.printers.Serial')
-    sell_products = mocker.spy(adapters.printers.SaremaX1, 'sell_products')
-    send = mocker.spy(adapters.printers.SaremaX1, 'send')
+    # prepare mock adapters
+    adapter_1 = mocker.Mock()
+    adapter_2 = mocker.Mock()
+    settings.PUSH_ADAPTERS = [adapter_1, adapter_2]
     # create some products
     products = mommy.make(Product, _quantity=2)
     # sold products
@@ -54,67 +50,34 @@ def test_receipt_post_print(alice_client, mocker, settings):
     response = alice_client.post(endpoint, data=sold_items)
     # the receipt has been created through the ``ReceiptSerializer``
     assert response.status_code == 201
-    assert sell_products.call_count == 1
-    assert send.call_count == 1
+    assert adapter_1.push.call_count == 1
+    assert adapter_2.push.call_count == 1
+    # check the given payload
+    args, _ = adapter_1.push.call_args_list[0]
+    items = args[0]
+    assert items[0]['description'] == products[0].name
+    assert items[1]['description'] == products[1].name
+    assert items[0]['price'] == '5.90'
+    assert items[1]['price'] == '2.00'
 
 
 @pytest.mark.django_db
-def test_receipt_post_without_print(alice_client, mocker):
+def test_receipt_post_rollback_on_adapters_errors(alice_client, mocker, settings):
     """
-    Ensure that a POST on the receipt endpoint doesn't print a receipt
-    if an internal Django settings is set to stop this action.
-        * create two products
-        * prepare a payload with 2 sold items
-        * POST the message
-        * expect that the receipt is not printed
-    """
-    # mock third party libraries
-    sell_products = mocker.spy(adapters.printers.SaremaX1, 'sell_products')
-    send = mocker.spy(adapters.printers.SaremaX1, 'send')
-    # create some products
-    products = mommy.make(Product, _quantity=2)
-    # sold products
-    sold_items = {
-        'products': [
-            {
-                'id': products[0].id,
-                'price': '5.90',
-            },
-            {
-                'id': products[1].id,
-                'price': '2.00',
-                'quantity': '2.0',
-            },
-        ]
-    }
-    # get the receipts endpoint
-    endpoint = reverse('registers:receipt-list')
-    response = alice_client.post(endpoint, data=sold_items)
-    # the receipt has been created through the ``ReceiptSerializer``
-    # without printing the receipt
-    assert response.status_code == 201
-    assert sell_products.call_count == 0
-    assert send.call_count == 0
-
-
-@pytest.mark.django_db
-def test_receipt_post_rollback_on_print_errors(alice_client, mocker, settings):
-    """
-    Ensure that a POST on the receipt endpoint prints a receipt
-    through the connected cash register. This test doesn't check
-    the validity of the ViewSet / Serializer but only assert
-    that the python-cash-register integration works properly.
+    Ensure that a POST on the receipt endpoint executes a rollback
+    if an internal error happens during adapters execution.
         * create two products
         * prepare a payload with 2 sold items
         * POST the message
         * expect that an exception is raised and that the database
           did a rollback
     """
-    # force the print
-    settings.REGISTER_PRINT = True
-    # simulate a serial exception
-    mock_serial = mocker.patch('registers.adapters.printers.Serial')
-    mock_serial.side_effect = SerialException
+    # prepare mock adapters
+    adapter_1 = mocker.Mock()
+    adapter_2 = mocker.Mock()
+    settings.PUSH_ADAPTERS = [adapter_1, adapter_2]
+    # simulate an exception
+    adapter_2.push.side_effect = CashRegisterNotReady
     # create some products
     products = mommy.make(Product, _quantity=3)
     # sold products
@@ -152,7 +115,7 @@ def test_convert_serializer():
     """
     Test the ``convert_serializer`` method so that for the given
     ``ReceiptSerializer`` it returns a list of sold items that must
-    be printed.
+    be sent to the push adapters.
     """
     # create a list of products
     products = mommy.make(Product, _quantity=3)

--- a/django-manager/tests/test_integration.py
+++ b/django-manager/tests/test_integration.py
@@ -11,7 +11,7 @@ from django.core.urlresolvers import reverse
 
 from serial import SerialException
 
-from registers import apiviews
+from registers import apiviews, adapters
 from registers.models import Product, Receipt
 from registers.receipts import convert_serializer
 from registers.serializers import ReceiptSerializer
@@ -30,9 +30,9 @@ def test_receipt_post_print(alice_client, mocker, settings):
     # force the print
     settings.REGISTER_PRINT = True
     # spy third party libraries and mock the serial port
-    mocker.patch('registers.receipts.Serial')
+    mocker.patch('registers.adapters.printers.Serial')
     convert_serializer = mocker.spy(apiviews, 'convert_serializer')
-    print_receipt = mocker.spy(apiviews, 'print_receipt')
+    print_receipt = mocker.spy(adapters.printers.CashRegisterAdapter, 'push')
     # create some products
     products = mommy.make(Product, _quantity=2)
     # sold products
@@ -70,7 +70,7 @@ def test_receipt_post_without_print(alice_client, mocker):
     """
     # mock third party libraries
     convert_serializer = mocker.patch('registers.apiviews.convert_serializer')
-    print_receipt = mocker.patch('registers.apiviews.print_receipt')
+    print_receipt = mocker.spy(adapters.printers.CashRegisterAdapter, 'push')
     # create some products
     products = mommy.make(Product, _quantity=2)
     # sold products
@@ -112,7 +112,7 @@ def test_receipt_post_rollback_on_print_errors(alice_client, mocker, settings):
     # force the print
     settings.REGISTER_PRINT = True
     # simulate a serial exception
-    mock_serial = mocker.patch('registers.receipts.Serial')
+    mock_serial = mocker.patch('registers.adapters.printers.Serial')
     mock_serial.side_effect = SerialException
     # create some products
     products = mommy.make(Product, _quantity=3)


### PR DESCRIPTION
### What it does

* add the `PUSH_ADAPTERS` setting that lists a set of `BaseAdapter` implementations that are executed when the API `ViewSet` is called. This makes the system pluggable and easy to test
* the current printing system is converted to a `CashRegisterAdapter`
* the `CashRegisterAdapter` is disabled by default