### PR TITLE
[adapter] DatadogAdapter implementation

### DIFF
--- a/django-manager/manager/settings/base.py
+++ b/django-manager/manager/settings/base.py
@@ -110,10 +110,14 @@ USE_TZ = True
 CURRENCIES = ('EUR',)
 
 # list of Adapters that are used to push data to third party services
+# Available adapters are:
+#   * 'registers.adapters.printers.CashRegisterAdapter'
 PUSH_ADAPTERS = [
-    # Available adapters are:
-    # 'registers.adapters.printers.CashRegisterAdapter',
+    'registers.adapters.services.DatadogAdapter',
 ]
+
+# Datadog adapter settings
+DATADOG_API_KEY = env('DJANGO_DATADOG_API_KEY', None)
 
 # cash register settings
 REGISTER_NAME = env('DJANGO_REGISTER_NAME', 'Shop')

--- a/django-manager/manager/settings/dev.py
+++ b/django-manager/manager/settings/dev.py
@@ -19,4 +19,8 @@ LOGGING['loggers'] = {
         'handlers': ['console'],
         'level': env('MANAGER_LOG_LEVEL', 'DEBUG'),
     },
+    'registers': {
+        'handlers': ['console'],
+        'level': env('MANAGER_LOG_LEVEL', 'DEBUG'),
+    },
 }

--- a/django-manager/manager/settings/production.py
+++ b/django-manager/manager/settings/production.py
@@ -29,4 +29,8 @@ LOGGING['loggers'] = {
         'handlers': ['console', 'syslog'],
         'level': env('MANAGER_LOG_LEVEL', 'INFO'),
     },
+    'registers': {
+        'handlers': ['console', 'syslog'],
+        'level': env('MANAGER_LOG_LEVEL', 'INFO'),
+    },
 }

--- a/django-manager/registers/adapters/services.py
+++ b/django-manager/registers/adapters/services.py
@@ -1,0 +1,63 @@
+import logging
+
+from django.conf import settings
+
+from datadog import initialize, ThreadStats
+
+from .base import BaseAdapter
+from .utils import slugify
+from ..exceptions import AdapterPushFailed
+
+
+logger = logging.getLogger(__name__)
+
+
+class DatadogAdapter(BaseAdapter):
+    """
+    DatadogAdapter sends the given `Receipt` values to a local
+    Datadog agent via dogstatsd.
+    """
+    METRIC_PREFIX = 'shop.{}'.format(slugify(settings.REGISTER_NAME))
+
+    def __init__(self):
+        # prepare the statsd client
+        options = {
+            'api_key': settings.DATADOG_API_KEY,
+        }
+        initialize(**options)
+
+        # start the statsd thread
+        disabled = not settings.DATADOG_API_KEY
+        self.statsd = ThreadStats()
+        self.statsd.start(flush_interval=1, roll_up_interval=1, disabled=disabled)
+        logger.debug('statsd thread initialized, disabled: %s', disabled)
+
+    def push(self, receipt):
+        """
+        Sends data to a local Datadog agent. The `Receipt` products
+        are properly tagged using a stringify function so that
+        they can be easily aggregated through Datadog backend.
+        """
+        try:
+            # count the receipt
+            timestamp = receipt.date.timestamp()
+            count_metric = '{prefix}.receipt.count'.format(prefix=self.METRIC_PREFIX)
+            self.statsd.increment(count_metric, timestamp=timestamp)
+
+            for item in receipt.sell_set.all():
+                # generate tags and metrics name
+                tags = ['product:{}'.format(slugify(item.product.name))]
+                items_count = '{prefix}.receipt.items.count'.format(prefix=self.METRIC_PREFIX)
+                receipt_amount = '{prefix}.receipt.amount'.format(prefix=self.METRIC_PREFIX)
+
+                # compute item metrics
+                quantity = item.quantity
+                total = float((item.price * item.quantity).amount)
+
+                # send data
+                self.statsd.increment(items_count, timestamp=timestamp, value=quantity, tags=tags)
+                self.statsd.increment(receipt_amount, timestamp=timestamp, value=total, tags=tags)
+
+            logger.debug('pushed metrics for %d sold items', receipt.sell_set.count())
+        except Exception:
+            raise AdapterPushFailed

--- a/django-manager/registers/adapters/utils.py
+++ b/django-manager/registers/adapters/utils.py
@@ -1,0 +1,8 @@
+from django.utils.text import slugify as url_slugify
+
+
+def slugify(text):
+    """
+    Returns a slug using underscores instead of dashes.
+    """
+    return url_slugify(text).replace('-', '_')

--- a/django-manager/registers/admin.py
+++ b/django-manager/registers/admin.py
@@ -4,6 +4,18 @@ from django.contrib import admin
 from .models import Product, Receipt, Sell
 
 
+def backfill(modeladmin, request, queryset):
+    """
+    Re-launch the adapters for the given `Receipt`
+    queryset.
+    """
+    for receipt in queryset:
+        for adapter in settings.PUSH_ADAPTERS:
+            # re-push data
+            adapter.push(receipt)
+backfill.short_description = 'Backfill data using Adapters'  # noqa
+
+
 class SellInline(admin.TabularInline):
     model = Sell
     extra = 1
@@ -11,6 +23,8 @@ class SellInline(admin.TabularInline):
 
 @admin.register(Receipt)
 class ReceiptAdmin(admin.ModelAdmin):
+    actions = [backfill]
+    ordering = ['-date']
     inlines = [
         SellInline,
     ]

--- a/django-manager/registers/apiviews.py
+++ b/django-manager/registers/apiviews.py
@@ -5,7 +5,6 @@ from rest_framework import mixins, viewsets
 from rest_framework.permissions import IsAdminUser
 
 from .models import Product, Receipt
-from .receipts import convert_serializer
 from .serializers import ProductSerializer, ReceiptSerializer
 
 
@@ -44,11 +43,8 @@ class ReceiptViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
         """
         with transaction.atomic():
             # create the ``Receipt`` model, honoring the ManyToMany
-            serializer.save()
-
-            # push items list to external components
-            items = convert_serializer(serializer)
+            receipt = serializer.save()
             for adapter in settings.PUSH_ADAPTERS:
                 # TODO: when an adapter is executed, we may store the
                 # execution so that it is not executed twice
-                adapter.push(items)
+                adapter.push(receipt)

--- a/django-manager/registers/serializers.py
+++ b/django-manager/registers/serializers.py
@@ -76,3 +76,5 @@ class ReceiptSerializer(serializers.Serializer):
                 price_currency=item['price_currency'],
             )
             sell.save()
+
+        return receipt

--- a/django-manager/tests/test_adapters.py
+++ b/django-manager/tests/test_adapters.py
@@ -5,72 +5,175 @@ integration works properly.
 """
 import pytest
 
+from django.utils import timezone
+
 from serial import SerialException
 
+from model_mommy import mommy
+
 from registers import adapters
+from registers.models import Product, Receipt, Sell
 from registers.exceptions import AdapterPushFailed
+from registers.adapters.services import DatadogAdapter
 from registers.adapters.printers import CashRegisterAdapter
 
 
-@pytest.mark.django_db
-def test_cash_register_adapter(mocker):
-    """
-    Ensure that a list of sold items is printed:
-        * prepare a payload with 2 sold items
-        * push the adapter
-        * expect that the receipt is printed
-    """
-    # initialize the adapter
-    adapter = CashRegisterAdapter()
-    # spy third party libraries and mock the serial port
-    mocker.patch('registers.adapters.printers.Serial')
-    sell_products = mocker.spy(adapters.printers.SaremaX1, 'sell_products')
-    send = mocker.spy(adapters.printers.SaremaX1, 'send')
-    # sold products
-    sold_items = [
-        {
-            'description': 'Croissant',
-            'price': '5.90',
-        },
-        {
-            'description': 'Begel',
-            'price': '2.00',
-            'quantity': '2.00',
-        },
-    ]
-    # push data
-    adapter.push(sold_items)
-    assert sell_products.call_count == 1
-    assert send.call_count == 1
-
-
-@pytest.mark.django_db
-def test_cash_register_adapter_failure(mocker):
-    """
-    Ensure that an AdapterPushFailed is raised when using this
-    adapter:
-        * prepare a payload with 2 sold items
-        * push the adapter
-        * expect that an exception is raised
-    """
-    # initialize the adapter
-    adapter = CashRegisterAdapter()
-    # mock the serial port so that it raises an Exception
-    serial_port = mocker.patch('registers.adapters.printers.Serial')
-    serial_port.side_effect = SerialException
-    # sold products
-    sold_items = [
-        {
-            'description': 'Croissant',
-            'price': '5.90',
-        },
-        {
-            'description': 'Begel',
-            'price': '2.00',
-            'quantity': '2.00',
-        },
-    ]
-    # push data and check the Exception
-    with pytest.raises(AdapterPushFailed) as excinfo:
+class TestCashRegisterAdapter:
+    @pytest.mark.django_db
+    def test_cash_register_adapter(self, mocker):
+        """
+        Ensure that a list of sold items is printed:
+            * prepare a payload with 2 sold items
+            * push the adapter
+            * expect that the receipt is printed
+        """
+        # initialize the adapter
+        adapter = CashRegisterAdapter()
+        # spy third party libraries and mock the serial port
+        mocker.patch('registers.adapters.printers.Serial')
+        sell_products = mocker.spy(adapters.printers.SaremaX1, 'sell_products')
+        send = mocker.spy(adapters.printers.SaremaX1, 'send')
+        # sold products
+        sold_items = [
+            {
+                'description': 'Croissant',
+                'price': '5.90',
+            },
+            {
+                'description': 'Begel',
+                'price': '2.00',
+                'quantity': '2.00',
+            },
+        ]
+        # push data
         adapter.push(sold_items)
-    assert excinfo.typename == 'CashRegisterNotReady'
+        assert sell_products.call_count == 1
+        assert send.call_count == 1
+
+    @pytest.mark.django_db
+    def test_cash_register_adapter_failure(self, mocker):
+        """
+        Ensure that an AdapterPushFailed is raised when using this
+        adapter:
+            * prepare a payload with 2 sold items
+            * push the adapter
+            * expect that an exception is raised
+        """
+        # initialize the adapter
+        adapter = CashRegisterAdapter()
+        # mock the serial port so that it raises an Exception
+        serial_port = mocker.patch('registers.adapters.printers.Serial')
+        serial_port.side_effect = SerialException
+        # sold products
+        sold_items = [
+            {
+                'description': 'Croissant',
+                'price': '5.90',
+            },
+            {
+                'description': 'Begel',
+                'price': '2.00',
+                'quantity': '2.00',
+            },
+        ]
+        # push data and check the Exception
+        with pytest.raises(AdapterPushFailed) as excinfo:
+            adapter.push(sold_items)
+        assert excinfo.typename == 'CashRegisterNotReady'
+
+
+class TestDatadogAdapter:
+    def setup(self):
+        # initialize the adapter
+        self.adapter = DatadogAdapter()
+
+    def tearDown(self):
+        self.adapter.statsd.stop()
+
+    def test_adapter_initialization(self):
+        """
+        Ensures that the adapter initializes a statsd server:
+            * the Adapter is initialized
+            * the statsd server is created at init time
+            * the flushing thread is not active because the API_KEY is not set
+        """
+        assert self.adapter.statsd._disabled is True
+
+    def test_adapter_enabled_with_api_key(self, settings):
+        """
+        Ensures that the statsd server is enabled if an API_KEY
+        is not provided:
+            * the Adapter is initialized
+            * the statsd server is created at init time
+            * the flushing thread must be active
+        """
+        try:
+            # the Datadog API_KEY is set
+            settings.DATADOG_API_KEY = 'testing-key'
+
+            # start the statsd thread that should remain disabled
+            adapter = DatadogAdapter()
+            assert adapter.statsd._disabled is False
+        finally:
+            adapter.statsd.stop()
+
+    @pytest.mark.django_db
+    def test_flushing_thread(self, mocker):
+        """
+        Ensures that the statsd server flushes metrics when the adapter
+        is invoked:
+            * a `Receipt` is created
+            * the flushing thread must send many metrics
+        """
+        # set spies
+        increment = mocker.spy(self.adapter.statsd, 'increment')
+
+        # create a receipt
+        product = mommy.make(Product, default_price=2.50)
+        receipt = mommy.make(Receipt)
+        # update the receipt auto_now_add attribute
+        new_time = timezone.datetime(2016, 1, 1)
+        receipt.date = new_time
+        receipt.save()
+        # add Sell items
+        Sell.objects.create(
+            receipt=receipt,
+            product=product,
+            quantity=1,
+            price=1.0,
+        )
+        # test the adapter
+        self.adapter.push(receipt)
+        assert increment.call_count == 3
+        # receipt count metric
+        args, kwargs = increment.call_args_list[0]
+        assert args[0] == 'shop.shop.receipt.count'
+        assert kwargs['timestamp'] == 1451606400.0
+        # items count metric
+        args, kwargs = increment.call_args_list[1]
+        assert args[0] == 'shop.shop.receipt.items.count'
+        assert 'product:' in kwargs['tags'][0]
+        assert kwargs['timestamp'] == 1451606400.0
+        assert kwargs['value'] == 1.0
+        # items amount metric
+        args, kwargs = increment.call_args_list[2]
+        assert args[0] == 'shop.shop.receipt.amount'
+        assert 'product:' in kwargs['tags'][0]
+        assert kwargs['timestamp'] == 1451606400.0
+        assert kwargs['value'] == 1.0
+
+    def test_flushing_thread_exception(self, mocker):
+        """
+        Ensures that the flushing thread raises an exception
+        if something goes wrong:
+            * a `Receipt` is created
+            * the flushing thread raises an error because of an issue
+        """
+        # set mocks
+        mocker.patch('registers.adapters.services.ThreadStats')
+        adapter = DatadogAdapter()
+        adapter.statsd.increment.side_effect = Exception
+        # push data and check the Exception
+        with pytest.raises(AdapterPushFailed) as excinfo:
+            adapter.push(Receipt())
+        assert excinfo.typename == 'AdapterPushFailed'

--- a/django-manager/tests/test_integration.py
+++ b/django-manager/tests/test_integration.py
@@ -54,11 +54,12 @@ def test_endpoint_calls_adapters(alice_client, mocker, settings):
     assert adapter_2.push.call_count == 1
     # check the given payload
     args, _ = adapter_1.push.call_args_list[0]
-    items = args[0]
-    assert items[0]['description'] == products[0].name
-    assert items[1]['description'] == products[1].name
-    assert items[0]['price'] == '5.90'
-    assert items[1]['price'] == '2.00'
+    receipt = args[0]
+    items = receipt.sell_set.all()
+    assert items[0].product.name == products[0].name
+    assert items[1].product.name == products[1].name
+    assert float(items[0].price.amount) == 5.9
+    assert float(items[1].price.amount) == 2.0
 
 
 @pytest.mark.django_db

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -9,6 +9,7 @@ psycopg2
 pytz
 
 # third-party
+datadog
 pillow
 pyserial
 python-cash-register

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,6 +6,8 @@
 #
 contextlib2==0.5.5        # via raven
 coverage==4.3.4           # via pytest-cov
+datadog==0.16.0
+decorator==4.0.11         # via datadog
 dj-database-url==0.4.2
 django-getenv==1.3.2
 django-money==0.10.2
@@ -29,6 +31,8 @@ pytest==3.0.7
 python-cash-register==0.1.1
 pytz==2017.2
 raven==6.0.0
+requests==2.13.0          # via datadog
+simplejson==3.10.0        # via datadog
 six==1.10.0               # via model-mommy
 uwsgi==2.0.15
 whitenoise==3.3.0


### PR DESCRIPTION
### What it does

Provides the `DatadogAdapter` implementation that stores saved `Receipt` objects in the Datadog backend. Receipts and sold items are stored as metrics:
* `shop.{shop_name}.receipt.count`
* `shop.{shop_name}.receipt.amount`
* `shop.{shop_name}.receipt.items.count`

A `backfill` action is available via Admin so that `Receipt` queryset can be re-submitted to registered adapters.

Closes #7.